### PR TITLE
use nock to mock requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,9 @@ language: node_js
 node_js:
   - stable
   - "4"
-branches:
-  only:
-    - master
+  - "5"
+  - "6"
+
 sudo: false
+
 script: npm test

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "mocha": "~2.3.4"
+    "mocha": "~2.3.4",
+    "nock": "^8.0.0"
   },
   "scripts": {
     "test": "mocha --ui tdd"

--- a/test/index.js
+++ b/test/index.js
@@ -1,17 +1,40 @@
 var ACME = require( '..' )
 var assert = require( 'assert' )
+var nock = require( 'nock' )
 
 suite( 'ACME', function() {
   
   var acme = new ACME({
-    baseUrl: 'https://acme-staging.api.letsencrypt.org',
+    baseUrl: 'https://mock_encrypt.example.com',
+  })
+
+  test( 'throws an error if baseUrl is not a string', function() {
+    assert.throws( function() {
+      new ACME({ baseUrl: 42 })
+    })
+
+
+    assert.throws( function() {
+      new ACME({ baseUrl: {} })
+    })
   })
   
   test( '#getDirectory()', function( next ) {
+    var payload = { 
+      'new-authz': 'https://mock_encrypt.example.com/acme/new-authz',
+      'new-cert': 'https://mock_encrypt.example.com/acme/new-cert',
+      'new-reg': 'https://mock_encrypt.example.com/acme/new-reg',
+      'revoke-cert': 'https://mock_encrypt.example.com/acme/revoke-cert' 
+    }
+    
+    nock( 'https://mock_encrypt.example.com' )
+      .get( '/directory' )
+      .reply( 200, payload )
+
     acme.getDirectory( function( error, data ) {
       assert.ifError( error )
       assert.ok( data )
-      console.log( data )
+      assert.deepStrictEqual( payload, data )
       next()
     })
   })


### PR DESCRIPTION
to enable/simplify further works on this lib I'd suggest mocking the service instead of using the actual live version. 